### PR TITLE
增加Redux前端数据层

### DIFF
--- a/client/actions/alertlog.js
+++ b/client/actions/alertlog.js
@@ -1,0 +1,34 @@
+import fetch from 'isomorphic-fetch'
+import { origin } from '../config'
+
+export const RECV_ALERTLOGS = 'RECV_ALERTLOGS'
+export const LOADING_ALERTLOGS = 'LOADING_ALERTLOGS'
+
+export const loadAlertLogs = () => dispatch => (dispatch({
+  type: LOADING_ALERTLOGS,
+  payload: {
+    loading: true,
+  },
+}))
+
+export const fetchAlertLogs = (page, pageSize) => dispatch =>
+  fetch(`${origin}/alertlogs?page=${page}&pageSize=${pageSize}`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: RECV_ALERTLOGS,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })

--- a/client/actions/scouts.js
+++ b/client/actions/scouts.js
@@ -1,0 +1,186 @@
+import fetch from 'isomorphic-fetch'
+import { origin } from '../config'
+
+export const LOADING_SCOUTS = 'LOADING_SCOUTS'
+export const RECV_SCOUTS = 'RECV_SCOUTS'
+export const PATCH_SCOUTS = 'PATCH_SCOUTS'
+export const CLEAN_SELECTED_SCOUTS = 'CLEAN_SELECTED_SCOUTS'
+export const SELECTED_SCOUTS = 'SELECTED_SCOUTS'
+
+export const ADD_SCOUT = 'ADD_SCOUT'
+export const DELETE_SCOUT = 'DELETE_SCOUT'
+export const PATCH_SCOUT = 'PATCH_SCOUT'
+export const FATCH_SCOUT = 'FATCH_SCOUT'
+
+export const CLEAN_CHOSEN_SCOUT = 'CLEAN_CHOSEN_SCOUT'
+
+export const loadScouts = () => dispatch => (dispatch({
+  type: LOADING_SCOUTS,
+  payload: {
+    loading: true,
+  },
+}))
+
+export const fetchScouts = () => dispatch =>
+  fetch(`${origin}/scouts`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: RECV_SCOUTS,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const patchScouts = (selectedScouts, patch) => dispatch =>
+  fetch(`${origin}/scouts`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ids: selectedScouts,
+      patch,
+    }),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: PATCH_SCOUTS,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const cleanSelectedScouts = () => dispatch => (dispatch({
+  type: CLEAN_SELECTED_SCOUTS,
+  payload: {},
+}))
+
+export const selectScouts = selectedScouts => dispatch => (dispatch({
+  type: SELECTED_SCOUTS,
+  payload: {
+    json: selectedScouts,
+  },
+}))
+
+
+export const addScout = data => dispatch =>
+  fetch(`${origin}/scout`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    }).then((json) => {
+      dispatch({
+        type: ADD_SCOUT,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const deleteScout = id => dispatch =>
+  fetch(`${origin}/scout/${id}`, { method: 'DELETE' })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+    }).then(() => {
+      dispatch({
+        type: DELETE_SCOUT,
+        payload: {
+          id,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const patchScout = (id, data) => dispatch =>
+  fetch(`${origin}/scout/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: PATCH_SCOUT,
+        payload: {
+          id,
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const fetchScout = id => dispatch =>
+  fetch(`${origin}/scout/${id}`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: FATCH_SCOUT,
+        payload: {
+          id,
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const cleanChosenScout = () => dispatch => (dispatch({
+  type: CLEAN_CHOSEN_SCOUT,
+  payload: {},
+}))

--- a/client/actions/settings.js
+++ b/client/actions/settings.js
@@ -1,0 +1,44 @@
+import fetch from 'isomorphic-fetch'
+import { origin } from '../config'
+
+export const RECV_SETTINGS = 'RECEIVE_SETTINGS'
+
+export const fetchSettings = () => dispatch =>
+  fetch(`${origin}/settings`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: RECV_SETTINGS,
+        payload: {
+          settings: json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })
+
+export const patchSettings = data => dispatch =>
+  fetch(`${origin}/settings`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  })
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      dispatch(fetchSettings())
+      return true
+    })
+    .catch((err) => {
+      console.error(err)
+      return false
+    })

--- a/client/actions/stats.js
+++ b/client/actions/stats.js
@@ -1,0 +1,72 @@
+import fetch from 'isomorphic-fetch'
+import { origin } from '../config'
+
+export const RECV_STATS = 'FETCH_STATS'
+export const RECV_STATS_HEALTH = 'FETCH_STATS_HEALTH'
+export const RECV_STATS_ERRORLOG = 'FETCH_STATS_ERRORLOG'
+
+export const fetchStats = (id, since) => dispatch =>
+  fetch(`${origin}/stats/${id}?since=${since}`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: RECV_STATS,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.log(err)
+      return false
+    })
+
+export const fetchStatsHealth = (id, since, interval) => dispatch =>
+  fetch(`${origin}/stats/health/${id}?since=${since}&interval=${interval}`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: RECV_STATS_HEALTH,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.log(err)
+      return false
+    })
+
+export const fetchStatsErrorlog = (id, since) => dispatch =>
+  fetch(`${origin}/stats/errorlog/${id}?since=${since}`)
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(res.statusText)
+      }
+      return res.json()
+    })
+    .then((json) => {
+      dispatch({
+        type: RECV_STATS_ERRORLOG,
+        payload: {
+          json,
+        },
+      })
+      return true
+    })
+    .catch((err) => {
+      console.log(err)
+      return false
+    })

--- a/client/components/AlertLog/index.jsx
+++ b/client/components/AlertLog/index.jsx
@@ -1,9 +1,8 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes as T } from 'react'
 import { Link } from 'react-router-dom'
 import { Table, Tag } from 'antd'
-import fetch from 'isomorphic-fetch'
 import moment from 'moment'
-import { origin, colors as C } from '../../config'
+import { colors as C } from '../../config'
 import $ from './index.css'
 
 function renderHTTP(record) {
@@ -25,32 +24,20 @@ function renderHTTP(record) {
 }
 
 class AlertLog extends Component {
-  state = {
-    loading: false,
-    alertLogs: [],
-  }
-  componentDidMount() {
-    this.fetch()
-  }
 
-  pageSize = 10
-  fetch(page = 1) {
-    this.setState({ loading: true })
-    fetch(`${origin}/alertlogs?page=${page}&pageSize=${this.pageSize}`)
-    .then(res => res.json())
-    .then((alertLogs) => {
-      this.setState({
-        alertLogs,
-        loading: false,
-      })
-    })
+  constructor(props) {
+    super(props)
+    this.handleChange = this.handleChange.bind(this)
   }
 
   handleChange = (pagination) => {
-    this.fetch(pagination.current)
+    const { loadData, pageSize } = this.props
+    loadData(pagination.current, pageSize)
   }
 
   render() {
+    const { loading, alertLogs } = this.props
+
     const columns = [
       {
         width: 100,
@@ -105,7 +92,7 @@ class AlertLog extends Component {
         bordered
         className={$.alertlog}
         columns={columns}
-        dataSource={this.state.alertLogs}
+        dataSource={alertLogs}
         expandedRowRender={renderHTTP}
         onChange={this.handleChange}
         rowKey="id"
@@ -113,10 +100,17 @@ class AlertLog extends Component {
           total: 200,
           simple: true,
         }}
-        loading={this.state.loading}
+        loading={loading}
       />
     )
   }
+}
+
+AlertLog.propTypes = {
+  loading: T.bool,
+  alertLogs: T.arrayOf(T.shape()),
+  pageSize: T.number,
+  loadData: T.func,
 }
 
 export default AlertLog

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -2,10 +2,10 @@ import { BrowserRouter as Router, Route } from 'react-router-dom'
 import React from 'react'
 import { Layout } from 'antd'
 
-import Dashboard from './Dashboard'
-import Settings from './Settings'
-import AlertLog from './AlertLog'
-import Stats from './Stats'
+import DashboardContainer from '../containers/DashboardContainer'
+import SettingsContainer from '../containers/SettingsContainer'
+import StatsContainer from '../containers/StatsContainer'
+import AlertLogContainer from '../containers/AlertLogContainer'
 import Header from './Header'
 import Footer from './Footer'
 
@@ -16,10 +16,10 @@ export default function App() {
       <Layout>
         <Header />
         <Content style={{ padding: '0 50px 0' }}>
-          <Route exact path="/" component={Dashboard} />
-          <Route path="/settings" component={Settings} />
-          <Route path="/alertlog" component={AlertLog} />
-          <Route path="/stats/:id" component={Stats} />
+          <Route exact path="/" component={DashboardContainer} />
+          <Route path="/settings" component={SettingsContainer} />
+          <Route path="/alertlog" component={AlertLogContainer} />
+          <Route path="/stats/:id" component={StatsContainer} />
         </Content>
         <Footer />
       </Layout>

--- a/client/components/Dashboard/Controls.jsx
+++ b/client/components/Dashboard/Controls.jsx
@@ -5,9 +5,6 @@ import OriginFilter from './OriginFilter'
 import $ from './Controls.css'
 
 export default class Controls extends Component {
-  state = {
-    isModalOpen: false,
-  }
   render() {
     return (
       <div style={{ padding: '16px 0' }}>

--- a/client/components/Dashboard/MultiModal.jsx
+++ b/client/components/Dashboard/MultiModal.jsx
@@ -15,24 +15,11 @@ class MultiModal extends Component {
       ), Object.create(null))
 
       if (data.fields.length) {
-        fetch(`${origin}/scouts`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            ids: this.props.selectedScouts,
-            patch,
-          }),
-        })
-        .then(res => res.json())
-        .then((json) => {
-          this.props.setScouts(
-            this.props.scouts.map(scout => (
-              this.props.selectedScouts.includes(scout.id) ?
-              Object.assign(scout, json.find(s => s.id === scout.id)) :
-              scout
-            )))
-          this.props.closeMultiModal()
-          message.success('修改成功')
+        this.props.patchScouts(this.props.selectedScouts, patch, (isSucc) => {
+          if (isSucc) {
+            this.props.closeMultiModal()
+            message.success('修改成功')
+          }
         })
       } else {
         this.props.closeMultiModal()
@@ -63,8 +50,7 @@ class MultiModal extends Component {
 }
 
 MultiModal.propTypes = {
-  scouts: T.arrayOf(T.shape()),
-  setScouts: T.func,
+  patchScouts: T.func,
   isOpen: T.bool,
   allTags: T.arrayOf(T.string),
   allRecipients: T.arrayOf(T.string),

--- a/client/components/Dashboard/Scouts.jsx
+++ b/client/components/Dashboard/Scouts.jsx
@@ -10,34 +10,26 @@ import $ from './Scouts.css'
 import randomColor from '../../utils/randomColor'
 
 export default class Scouts extends Component {
-  state = {
-    loading: true,
-  }
   componentDidMount() {
     const get = () => {
-      this.setState({ loading: true })
-      fetch(`${origin}/scouts`)
-      .then(res => res.json())
-      .then((scouts) => {
-        this.props.setScouts(scouts.reverse())
-        this.setState({ loading: false })
-      })
+      this.props.fetchScouts()
       this.timeout = setTimeout(get, 60000)
     }
     get()
   }
+
   componentWillUnmount() {
     clearTimeout(this.timeout)
   }
+
   delScout(id) {
-    fetch(`${origin}/scout/${id}`, {
-      method: 'DELETE',
-    })
-    .then(() => {
-      message.success('删除成功')
-      this.props.setScouts(this.props.scouts.filter(scout => scout.id !== id))
+    this.props.deleteScout(id, (isSucc) => {
+      if (isSucc) {
+        message.success('删除成功')
+      }
     })
   }
+
   render() {
     const columns = [
       {
@@ -130,7 +122,7 @@ export default class Scouts extends Component {
       columns={columns}
       rowKey="id"
       dataSource={this.props.scouts}
-      loading={this.state.loading}
+      loading={this.props.loading}
       rowSelection={this.props.selectable ? {
         type: 'checkbox',
         selectedRowKeys: this.props.selectedScouts,
@@ -146,7 +138,9 @@ Scouts.propTypes = {
   })),
   selectedScouts: T.arrayOf(T.string),
   handleSelectChange: T.func,
-  setScouts: T.func,
+  deleteScout: T.func,
+  fetchScouts: T.func,
+  loading: T.bool,
   openModal: T.func,
   selectable: T.bool,
 }

--- a/client/components/Dashboard/index.jsx
+++ b/client/components/Dashboard/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes as T } from 'react'
 import Scouts from './Scouts'
 import ScoutModal from './ScoutModal'
 import Controls from './Controls'
@@ -10,28 +10,31 @@ export default class Dashboard extends Component {
     selectable: false,
     isModalOpen: false,
     isMultiModalOpen: false,
-    scouts: [],
-    selectedScouts: [],
-  }
-  setScouts = (scouts) => {
-    this.setState({ scouts })
   }
   handleSelectChange = (selectedScouts) => {
-    this.setState({ selectedScouts })
+    this.props.selectScouts(selectedScouts)
   }
-  openModal = (activeId) => {
-    this.setState({
-      isModalOpen: true,
-      activeId,
-    })
+  openModal = (id) => {
+    const me = this
+    if (id !== undefined) {
+      this.props.fetchScout(id, (isSucc) => {
+        if (isSucc) {
+          me.setState({ isModalOpen: true })
+        }
+      })
+    } else {
+      me.setState({ isModalOpen: true })
+    }
   }
   closeModal = () => {
+    this.props.cleanChosenScout()
     this.setState({ isModalOpen: false })
   }
   openMultiModal = () => {
     this.setState({ isMultiModalOpen: true })
   }
   closeMultiModal = () => {
+    this.props.cleanSelectedScouts()
     this.setState({ isMultiModalOpen: false })
   }
   select = () => {
@@ -41,15 +44,15 @@ export default class Dashboard extends Component {
     this.setState({ selectable: false })
   }
   render() {
-    const { scouts } = this.state
+    const { scouts } = this.props
     const allTags = union(scouts.map(scout => scout.tags))
     const allRecipients = union(scouts.map(scout => scout.recipients))
     return (
       <div>
         <Controls
           selectable={this.state.selectable}
-          scouts={this.state.scouts}
-          selectedScouts={this.state.selectedScouts}
+          scouts={scouts}
+          selectedScouts={this.props.selectedScouts}
           openModal={this.openModal}
           openMultiModal={this.openMultiModal}
           handleSelectChange={this.handleSelectChange}
@@ -58,26 +61,30 @@ export default class Dashboard extends Component {
         />
         <Scouts
           selectable={this.state.selectable}
-          selectedScouts={this.state.selectedScouts}
-          scouts={this.state.scouts}
+          selectedScouts={this.props.selectedScouts}
+          scouts={scouts}
           handleSelectChange={this.handleSelectChange}
-          setScouts={this.setScouts}
+          fetchScouts={this.props.fetchScouts}
+          deleteScout={this.props.deleteScout}
+          loading={this.props.loading}
           openModal={this.openModal}
         />
         <ScoutModal
           allTags={allTags}
           allRecipients={allRecipients}
-          scouts={this.state.scouts}
-          setScouts={this.setScouts}
-          activeId={this.state.activeId}
+          scout={this.props.scout}
+          fetchScout={this.props.fetchScout}
+          patchScout={this.props.patchScout}
+          addScout={this.props.addScout}
+          activeId={this.props.activeId}
           isOpen={this.state.isModalOpen}
           closeModal={this.closeModal}
         />
         <MultiModal
           allTags={allTags}
           allRecipients={allRecipients}
-          selectedScouts={this.state.selectedScouts}
-          scouts={this.state.scouts}
+          selectedScouts={this.props.selectedScouts}
+          patchScouts={this.props.patchScouts}
           setScouts={this.setScouts}
           isOpen={this.state.isMultiModalOpen}
           closeMultiModal={this.closeMultiModal}
@@ -85,4 +92,21 @@ export default class Dashboard extends Component {
       </div>
     )
   }
+}
+
+Dashboard.propTypes = {
+  scouts: T.arrayOf(T.shape()),
+  scout: T.object,
+  selectedScouts: T.arrayOf(T.shape()),
+  activeId: T.string,
+  fetchScouts: T.func,
+  patchScouts: T.func,
+  cleanSelectedScouts: T.func,
+  selectScouts: T.func,
+  addScout: T.func,
+  deleteScout: T.func,
+  patchScout: T.func,
+  fetchScout: T.func,
+  cleanChosenScout: T.func,
+  loading: T.bool,
 }

--- a/client/components/Settings/index.jsx
+++ b/client/components/Settings/index.jsx
@@ -1,7 +1,5 @@
 import React, { Component, PropTypes as T } from 'react'
 import { Form, Icon, Button, Switch, message } from 'antd'
-import fetch from 'isomorphic-fetch'
-import { origin } from '../../config'
 import $ from './index.css'
 import AlertURLDetail from './AlertURLDetail'
 import PrefixedURL from '../Dashboard/forms/custom/PrefixedURL'
@@ -9,25 +7,16 @@ import PrefixedURL from '../Dashboard/forms/custom/PrefixedURL'
 class Settings extends Component {
   state = {
     isAlertURLDetailVisible: false,
-    isTesting: false,
-    settings: {},
   }
-  componentDidMount() {
-    fetch(`${origin}/settings`)
-    .then(res => res.json())
-    .then((settings) => {
-      this.setState({ settings })
-    })
-  }
+
   submit = () => {
     const data = this.props.form.getFieldsValue()
-    fetch(`${origin}/settings`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    })
-    .then(() => {
-      message.success('更新成功')
+    this.props.onSubmit(data, (isSucc) => {
+      if (isSucc) {
+        message.success('更新成功')
+      } else {
+        message.success('更新失败')
+      }
     })
   }
   toggleAlertURLDetail = () => {
@@ -38,8 +27,8 @@ class Settings extends Component {
   render() {
     const { Item } = Form
     const { getFieldDecorator } = this.props.form
-    const { settings } = this.state
     const { getFieldValue } = this.props.form
+    const { settings } = this.props
 
     return (
       <div className={$.container}>
@@ -83,6 +72,8 @@ Settings.propTypes = {
     getFieldsValue: T.func,
     getFieldValue: T.func,
   }),
+  onSubmit: T.func,
+  settings: T.object,
 }
 
 export default Form.create()(Settings)

--- a/client/components/Stats/ErrorLog.jsx
+++ b/client/components/Stats/ErrorLog.jsx
@@ -1,29 +1,15 @@
 import React, { Component, PropTypes as T } from 'react'
 import moment from 'moment'
 import { Timeline } from 'antd'
-import { origin } from '../../config'
 import $ from './ErrorLog.css'
 import formatTinyTime from '../../utils/formatTinyTime'
 import calendar from '../../utils/calendar'
 
 export default class ErrorLog extends Component {
-  state = {
-    logs: [],
-  }
-  componentDidMount() {
-    moment.locale('zh-cn')
-    const { id, since } = this.props
-    fetch(`${origin}/stats/errorlog/${id}?since=${since}`)
-    .then(res => res.json())
-    .then((json) => {
-      this.setState({
-        logs: json,
-      })
-    })
-  }
   render() {
+    moment.locale('zh-cn')
     const { Item } = Timeline
-    const { logs } = this.state
+    const { logs } = this.props
 
     return (
       <div className={$.errorlog}>
@@ -74,6 +60,5 @@ export default class ErrorLog extends Component {
 }
 
 ErrorLog.propTypes = {
-  id: T.string,
-  since: T.number,
+  logs: T.arrayOf(T.shape()),
 }

--- a/client/components/Stats/Health.jsx
+++ b/client/components/Stats/Health.jsx
@@ -8,74 +8,70 @@ import healthToColor from '../../utils/healthToColor'
 
 export default class Health extends Component {
   componentDidMount() {
-    const { id, since, interval } = this.props
-    fetch(`${origin}/stats/health/${id}?since=${since}&interval=${interval}`)
-    .then(res => res.json())
-    .then((json) => {
-      const data = json.statuses.map(({ OK = 0, Errors = {}, Idle = 0 }, i) => {
-        const errors = Object.keys(Errors)
-        const totalErrors = errors.reduce((p, e) => p + Errors[e], 0)
+    const { since, interval, health: json } = this.props
+    const data = json.statuses.map(({ OK = 0, Errors = {}, Idle = 0 }, i) => {
+      const errors = Object.keys(Errors)
+      const totalErrors = errors.reduce((p, e) => p + Errors[e], 0)
 
-        const total = OK + totalErrors + Idle
-        const validTotal = OK + totalErrors
-        const time = moment(json.now - ((i + 0.5) * interval * 60 * 1000))
-        return {
-          OK,
-          totalErrors,
-          Errors,
-          Idle,
-          time: moment(time),
-          health: validTotal ? OK / validTotal : 0,
-          idleRatio: total ? Idle / total : 1,
-        }
-      })
-
-      const svg = d3.select(this.svg)
-      const margin = { top: 20, right: 20, bottom: 30, left: 20 }
-      const width = +svg.attr('width') - margin.left - margin.right
-      const height = +svg.attr('height') - margin.top - margin.bottom
-      const barWidth = width / data.length / 1.1
-
-      const x = d3.scaleTime().domain([moment(json.now), moment(json.now).subtract(since, 'minutes')]).range([0, width])
-      const y = d3.scaleLinear().domain([0, 1]).range([0, height - barWidth])
-
-      const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
-
-      const tip = d3Tip()
-      .attr('class', $.tip)
-      .offset([-10, 0])
-      .html(d => `
-        ${d.time.isSame(moment(), 'day') ? '' : '昨日 '}
-        ${d.time.format('HH:mm')} 左右
-        ${d.OK + d.totalErrors + d.Idle ?
-         `${d.OK ? `<p>OK：${d.OK}</p>` : ''}
-          ${Object.keys(d.Errors).map(e => `<p>${e}：${d.Errors[e]}</p>`).join('')}
-          ${d.Idle ? `<p>Idle：${d.Idle}</p>` : ''}` :
-          `<p class="${$.default}">无数据</p>`}
-        <div class="${$.arrow}">
-      `)
-
-      svg.call(tip)
-
-      g.append('g')
-      .attr('class', $.axisx)
-      .attr('transform', `translate(0,${height})`)
-      .call(d3.axisBottom(x))
-
-      g.selectAll('rect')
-      .data(data)
-      .enter().append('rect')
-      .attr('class', $.bar)
-      .attr('fill', d => healthToColor(d.health))
-      .attr('opacity', d => 1 - d.idleRatio)
-      .attr('x', d => x(d.time))
-      .attr('y', d => height - y(d.health) - barWidth)
-      .attr('width', barWidth)
-      .attr('rx', barWidth / 2)
-      .attr('height', d => y(d.health) + barWidth)
-      .on('mouseover', tip.show)
-      .on('mouseout', tip.hide)
+      const total = OK + totalErrors + Idle
+      const validTotal = OK + totalErrors
+      const time = moment(json.now - ((i + 0.5) * interval * 60 * 1000))
+      return {
+        OK,
+        totalErrors,
+        Errors,
+        Idle,
+        time: moment(time),
+        health: validTotal ? OK / validTotal : 0,
+        idleRatio: total ? Idle / total : 1,
+      }
     })
+
+    const svg = d3.select(this.svg)
+    const margin = { top: 20, right: 20, bottom: 30, left: 20 }
+    const width = +svg.attr('width') - margin.left - margin.right
+    const height = +svg.attr('height') - margin.top - margin.bottom
+    const barWidth = width / data.length / 1.1
+
+    const x = d3.scaleTime().domain([moment(json.now), moment(json.now).subtract(since, 'minutes')]).range([0, width])
+    const y = d3.scaleLinear().domain([0, 1]).range([0, height - barWidth])
+
+    const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`)
+
+    const tip = d3Tip()
+    .attr('class', $.tip)
+    .offset([-10, 0])
+    .html(d => `
+      ${d.time.isSame(moment(), 'day') ? '' : '昨日 '}
+      ${d.time.format('HH:mm')} 左右
+      ${d.OK + d.totalErrors + d.Idle ?
+       `${d.OK ? `<p>OK：${d.OK}</p>` : ''}
+        ${Object.keys(d.Errors).map(e => `<p>${e}：${d.Errors[e]}</p>`).join('')}
+        ${d.Idle ? `<p>Idle：${d.Idle}</p>` : ''}` :
+        `<p class="${$.default}">无数据</p>`}
+      <div class="${$.arrow}">
+    `)
+
+    svg.call(tip)
+
+    g.append('g')
+    .attr('class', $.axisx)
+    .attr('transform', `translate(0,${height})`)
+    .call(d3.axisBottom(x))
+
+    g.selectAll('rect')
+    .data(data)
+    .enter().append('rect')
+    .attr('class', $.bar)
+    .attr('fill', d => healthToColor(d.health))
+    .attr('opacity', d => 1 - d.idleRatio)
+    .attr('x', d => x(d.time))
+    .attr('y', d => height - y(d.health) - barWidth)
+    .attr('width', barWidth)
+    .attr('rx', barWidth / 2)
+    .attr('height', d => y(d.health) + barWidth)
+    .on('mouseover', tip.show)
+    .on('mouseout', tip.hide)
   }
   render() {
     return (
@@ -91,7 +87,7 @@ export default class Health extends Component {
 }
 
 Health.propTypes = {
-  id: T.string,
+  health: T.object,
   since: T.number,
   interval: T.number,
 }

--- a/client/components/Stats/Overview.jsx
+++ b/client/components/Stats/Overview.jsx
@@ -1,17 +1,8 @@
 import React, { Component, PropTypes as T } from 'react'
 import formatTinyTime from '../../utils/formatTinyTime'
-import { origin } from '../../config'
 import $ from './Overview.css'
 
 export default class Overview extends Component {
-  state = {}
-  componentDidMount() {
-    fetch(`${origin}/stats/${this.props.id}?since=${this.props.since}`)
-    .then(res => res.json())
-    .then((json) => {
-      this.setState(json)
-    })
-  }
   render() {
     const {
       name,
@@ -22,7 +13,7 @@ export default class Overview extends Component {
       Error = 0,
       Idle = 0,
       meanResponseTime,
-    } = this.state
+    } = this.props.common
     const total = OK + Error + Idle
     const health = total ? (OK + Idle) / total : 0
     return (
@@ -61,6 +52,6 @@ export default class Overview extends Component {
 }
 
 Overview.propTypes = {
-  id: T.string,
+  common: T.object,
   since: T.number,
 }

--- a/client/components/Stats/index.jsx
+++ b/client/components/Stats/index.jsx
@@ -4,29 +4,25 @@ import Health from './Health'
 import ErrorLog from './ErrorLog'
 import $ from './index.css'
 
-class Stats extends Component {
-  state = {
-    since: 1440,
-    interval: 30,
-  }
+export default class Stats extends Component {
   render() {
-    const { id } = this.props.match.params
+    const { id, since, interval } = this.props
+
     return (
       <div className={$.stats}>
-        <Overview id={id} since={this.state.since} />
-        <Health id={id} since={this.state.since} interval={this.state.interval} />
-        <ErrorLog id={id} since={this.state.since} />
+        <Overview id={id} since={since} common={this.props.common} />
+        <Health id={id} since={since} interval={interval} health={this.props.health} />
+        <ErrorLog id={id} since={since} logs={this.props.logs} />
       </div>
     )
   }
 }
 
 Stats.propTypes = {
-  match: T.shape({
-    params: T.shape({
-      id: T.string,
-    }),
-  }),
+  common: T.object,
+  health: T.object,
+  logs: T.arrayOf(T.shape()),
+  id: T.string,
+  since: T.number,
+  interval: T.number,
 }
-
-export default Stats

--- a/client/containers/AlertLogContainer.jsx
+++ b/client/containers/AlertLogContainer.jsx
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes as T } from 'react'
+import { connect } from 'react-redux'
+import { fetchAlertLogs, loadAlertLogs } from '../actions/alertlog'
+import AlertLog from '../components/AlertLog/index'
+
+class AlertLogContainer extends Component {
+
+  componentDidMount() {
+    this.props.loadData(1, this.props.pageSize)
+  }
+
+  render() {
+    return (
+      <AlertLog {...this.props} />
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  loading: state.alertlog.loading,
+  alertLogs: state.alertlog.alertLogs,
+  pageSize: 10,
+})
+
+const mapDispatchToProps = dispatch => ({
+  loadData: (page, pageSize) => {
+    dispatch(loadAlertLogs())
+    dispatch(fetchAlertLogs(page, pageSize))
+  },
+})
+
+AlertLogContainer.propTypes = {
+  loadData: T.func,
+  pageSize: T.number,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AlertLogContainer)

--- a/client/containers/DashboardContainer.jsx
+++ b/client/containers/DashboardContainer.jsx
@@ -1,0 +1,67 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { loadScouts, fetchScouts, patchScouts,
+  addScout, deleteScout, patchScout, fetchScout,
+  cleanChosenScout, cleanSelectedScouts, selectScouts } from '../actions/scouts'
+import Dashboard from '../components/Dashboard/index'
+
+class DashboardContainer extends Component {
+  render() {
+    return (
+      <Dashboard {...this.props} />
+    )
+  }
+}
+
+const mapStateToProps = state => ({
+  loading: state.scouts.loading,
+  scouts: state.scouts.scouts,
+  scout: state.scouts.chosenScout,
+  activeId: state.scouts.activeId,
+  selectedScouts: state.scouts.selectedScouts,
+})
+
+const mapDispatchToProps = dispatch => ({
+  fetchScouts: () => {
+    dispatch(loadScouts())
+    dispatch(fetchScouts())
+  },
+  patchScouts: (selectedScouts, patch, callback) => {
+    dispatch(loadScouts())
+    dispatch(patchScouts(selectedScouts, patch)).then((isSucc) => {
+      (callback !== undefined) && callback(isSucc)
+    })
+  },
+  cleanSelectedScouts: () => {
+    dispatch(cleanSelectedScouts())
+  },
+  selectScouts: (selectedScouts) => {
+    dispatch(selectScouts(selectedScouts))
+  },
+
+  addScout: (data, callback) => {
+    dispatch(addScout(data)).then((isSucc) => {
+      (callback !== undefined) && callback(isSucc)
+    })
+  },
+  deleteScout: (id, callback) => {
+    dispatch(deleteScout(id)).then((isSucc) => {
+      (callback !== undefined) && callback(isSucc)
+    })
+  },
+  patchScout: (id, data, callback) => {
+    dispatch(patchScout(id, data)).then((isSucc) => {
+      (callback !== undefined) && callback(isSucc)
+    })
+  },
+  fetchScout: (id, callback) => {
+    dispatch(fetchScout(id)).then((isSucc) => {
+      (callback !== undefined) && callback(isSucc)
+    })
+  },
+  cleanChosenScout: () => {
+    dispatch(cleanChosenScout())
+  },
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(DashboardContainer)

--- a/client/containers/SettingsContainer.jsx
+++ b/client/containers/SettingsContainer.jsx
@@ -1,0 +1,36 @@
+import React, { Component, PropTypes as T } from 'react'
+import { connect } from 'react-redux'
+import { fetchSettings, patchSettings } from '../actions/settings'
+import Settings from '../components/Settings/index'
+
+class SettingsContainer extends Component {
+
+  componentWillMount() {
+    this.props.onLoad()
+  }
+
+  render() {
+    return (
+      <Settings {...this.props} />
+    )
+  }
+}
+
+const mapStateToProps = state => ({ settings: state.settings.settings })
+
+const mapDispatchToProps = dispatch => ({
+  onSubmit: (data, callback) => {
+    dispatch(patchSettings(data)).then((isSucc) => {
+      (callback !== undefined) && callback(isSucc)
+    })
+  },
+  onLoad: () => {
+    dispatch(fetchSettings())
+  },
+})
+
+SettingsContainer.propTypes = {
+  onLoad: T.func,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SettingsContainer)

--- a/client/containers/StatsContainer.jsx
+++ b/client/containers/StatsContainer.jsx
@@ -1,0 +1,55 @@
+import React, { Component, PropTypes as T } from 'react'
+import { connect } from 'react-redux'
+import { fetchStats, fetchStatsHealth, fetchStatsErrorlog } from '../actions/stats'
+import Stats from '../components/Stats/index'
+
+class StatsContainer extends Component {
+  state = {
+    loadFinish: false,
+  }
+
+  componentWillMount() {
+    const { id, since, interval } = this.props
+    const me = this
+    this.props.onLoad(id, since, interval, (isSucc) => {
+      me.setState({ loadFinish: isSucc })
+    })
+  }
+
+  render() {
+    return (
+      this.state.loadFinish && <Stats {...this.props} />
+    )
+  }
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  id: ownProps.match.params.id,
+  since: 1440,
+  interval: 30,
+  common: state.stats.common,
+  health: state.stats.health,
+  logs: state.stats.logs,
+})
+
+const mapDispatchToProps = dispatch => ({
+  onLoad: (id, since, interval, callback) => {
+    Promise.all([
+      dispatch(fetchStats(id, since)),
+      dispatch(fetchStatsHealth(id, since, interval)),
+      dispatch(fetchStatsErrorlog(id, since)),
+    ]).then((results) => {
+      (callback !== undefined) && callback(results.every(e => (e === true)))
+    })
+  },
+})
+
+StatsContainer.propTypes = {
+  id: T.string,
+  since: T.number,
+  interval: T.number,
+  onLoad: T.func,
+}
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(StatsContainer)

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,11 +1,29 @@
 import ReactDOM from 'react-dom'
 import React from 'react'
+import { createStore, applyMiddleware } from 'redux'
+import { Provider } from 'react-redux'
+import thunkMiddleware from 'redux-thunk'
 
 import App from './components/App'
+import reducer from './reducers'
+
 import './index.css'
 
 const root = document.getElementById('root')
-const render = () => { ReactDOM.render(<App />, root) }
+const store = createStore(
+  reducer,
+  applyMiddleware(
+    thunkMiddleware,
+  ),
+)
+
+const render = () => {
+  ReactDOM.render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+    root)
+}
 
 render()
 if (module.hot) {

--- a/client/reducers/alertlog.js
+++ b/client/reducers/alertlog.js
@@ -1,0 +1,20 @@
+import { LOADING_ALERTLOGS, RECV_ALERTLOGS } from '../actions/alertlog'
+
+const handlerAlertLogs = (state = {
+  loading: false,
+  alertLogs: [],
+}, action) => {
+  switch (action.type) {
+    case LOADING_ALERTLOGS:
+      return Object.assign({}, state, { loading: action.payload.loading })
+    case RECV_ALERTLOGS:
+      return Object.assign({}, state, {
+        loading: false,
+        alertLogs: action.payload.json,
+      })
+    default:
+      return state
+  }
+}
+
+export default handlerAlertLogs

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -1,0 +1,14 @@
+import { combineReducers } from 'redux'
+import settings from './settings'
+import stats from './stats'
+import alertlog from './alertlog'
+import scouts from './scouts'
+
+const scoutApp = combineReducers({
+  settings,
+  stats,
+  alertlog,
+  scouts,
+})
+
+export default scoutApp

--- a/client/reducers/scouts.js
+++ b/client/reducers/scouts.js
@@ -1,0 +1,74 @@
+import { LOADING_SCOUTS, RECV_SCOUTS, PATCH_SCOUTS,
+  ADD_SCOUT, DELETE_SCOUT, PATCH_SCOUT, FATCH_SCOUT,
+  CLEAN_CHOSEN_SCOUT, CLEAN_SELECTED_SCOUTS, SELECTED_SCOUTS } from '../actions/scouts'
+
+const handlerScouts = (state = {
+  loading: false,
+  scouts: [],
+  chosenScout: {},
+  activeId: undefined,
+  selectedScouts: [],
+}, action) => {
+  switch (action.type) {
+    case LOADING_SCOUTS:
+      return Object.assign({}, state, { loading: action.payload.loading })
+    case RECV_SCOUTS:
+      return Object.assign({}, state, {
+        loading: false,
+        scouts: action.payload.json.reverse(),
+      })
+    case PATCH_SCOUTS:
+      return Object.assign({}, state, {
+        loading: false,
+        scouts: state.scouts.map((scout) => {
+          for (const newScout of action.payload.json) {
+            if (scout.id === newScout.id) {
+              return newScout
+            }
+          }
+          return scout
+        }),
+      })
+    case CLEAN_SELECTED_SCOUTS:
+      return Object.assign({}, state, {
+        selectedScouts: [],
+      })
+    case SELECTED_SCOUTS:
+      return Object.assign({}, state, {
+        selectedScouts: action.payload.json,
+      })
+
+
+    case ADD_SCOUT:
+      return Object.assign({}, state, { scouts: [
+        action.payload.json,
+        ...state.scouts,
+      ] })
+    case DELETE_SCOUT:
+      return Object.assign({}, state, {
+        scouts: state.scouts.filter(scout => scout.id !== action.payload.id),
+      })
+    case PATCH_SCOUT:
+      return Object.assign({}, state, {
+        state: state.scouts.map(scout => (
+          scout.id === action.payload.id ? Object.assign(scout, action.payload.json) : scout
+        )),
+      })
+    case FATCH_SCOUT:
+      return Object.assign({}, state, {
+        chosenScout: action.payload.json,
+        activeId: action.payload.id,
+      })
+    case CLEAN_CHOSEN_SCOUT:
+      return Object.assign({}, state, {
+        chosenScout: {},
+        activeId: undefined,
+      })
+
+
+    default:
+      return state
+  }
+}
+
+export default handlerScouts

--- a/client/reducers/settings.js
+++ b/client/reducers/settings.js
@@ -1,0 +1,15 @@
+import { RECV_SETTINGS } from '../actions/settings'
+
+const handleSettings = (state = {
+  settings: {},
+}, action) => {
+  switch (action.type) {
+    case RECV_SETTINGS:
+      return Object.assign({}, state, { settings: action.payload.settings })
+    default:
+      return state
+  }
+}
+
+
+export default handleSettings

--- a/client/reducers/stats.js
+++ b/client/reducers/stats.js
@@ -1,0 +1,21 @@
+import { RECV_STATS, RECV_STATS_HEALTH, RECV_STATS_ERRORLOG } from '../actions/stats'
+
+const handleStats = (state = {
+  common: {},
+  health: {},
+  logs: [],
+}, action) => {
+  switch (action.type) {
+    case RECV_STATS:
+      return Object.assign({}, state, { common: action.payload.json })
+    case RECV_STATS_HEALTH:
+      return Object.assign({}, state, { health: action.payload.json })
+    case RECV_STATS_ERRORLOG:
+      return Object.assign({}, state, { logs: action.payload.json })
+    default:
+      return state
+  }
+}
+
+
+export default handleStats

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
     "react": "^15.4.2",
     "react-codemirror": "^0.3.0",
     "react-dom": "^15.4.2",
+    "react-redux": "^5.0.5",
     "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",
+    "redux": "^3.7.2",
+    "redux-thunk": "^2.2.0",
     "restify": "^4.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### 使用redux重构前端数据层

增加组件
- "react-redux": "^5.0.5"
- "redux": "^3.7.2"
- "redux-thunk": "^2.2.0"

为Dashboard，AlertLogs，Settings，Stats四个主要组件分别增加action，reducer和container
action中有网络请求，取到结果分发给reducer操纵全局state
container负责调用action修改全局state与向下传递props

由于功能较少，只手动测试功能正常工作。